### PR TITLE
Create missing file paths and Close Rep file with each iteration

### DIFF
--- a/plot_figure_2.py
+++ b/plot_figure_2.py
@@ -3,7 +3,9 @@ import pandas as pd
 import os 
 import matplotlib.pyplot as plt
 
-folder = "numerical_data/mean_behavior/"
+folder = "./numerical_data/mean_behavior/"
+if not os.path.exists(folder):
+	os.makedirs(folder)
 L = os.listdir( folder )
 L = [i for i in L if 'DS' not in i]
 
@@ -40,7 +42,9 @@ plt.xlabel(r'$n_0$')
 plt.ylabel(r'GR ')
 plt.tight_layout()
 
-plt.savefig('Figures/GrowthLaw_.png')
+if not os.path.exists('./figures'):
+	os.makedirs('./figures')
+plt.savefig('./figures/GrowthLaw_.png')
 
 
 plt.figure(dpi=300, figsize=(8,3))
@@ -59,7 +63,9 @@ plt.xlabel(r'$n_0$')
 plt.ylabel(r'GR')
 plt.tight_layout()
 
-plt.savefig('figures/main_figures/figure_2_growth_law.png')
+if not os.path.exists('./figures/main_figures'):
+	os.makedirs('./figures/main_figures')
+plt.savefig('./figures/main_figures/figure_2_growth_law.png')
 
 plt.figure(dpi=300, figsize=(3,3))
 plt.scatter(GR,[R_mean[i]/cellSize_woR[i] for i in range(len(R_mean))],marker='o', label='r', alpha=0.5, ec='black')
@@ -68,7 +74,7 @@ plt.legend()
 plt.xlabel(r'GR')
 plt.ylabel('Mean content number per cell')
 plt.tight_layout()
-plt.savefig('figures/ratio_law.png')
+plt.savefig('./figures/ratio_law.png')
 plt.show()
 
 

--- a/simulation_figure2.cpp
+++ b/simulation_figure2.cpp
@@ -11,7 +11,7 @@ std::ofstream file;
 std::vector<double> n0_vec = {0.01, 0.02, 0.05,0.1,0.2, 0.5, 1.0, 2.0, 5.0,10, 20.0, 50.0, 100.0, 200.0, 500.0}; 
 
 for( int rep=0; rep<100; rep++){
-file.open("numerical_data/mean_behavior/Rep_"+std::to_string(rep)+".txt"); 
+file.open("./numerical_data/mean_behavior/Rep_"+std::to_string(rep)+".txt"); 
 file <<"n0,m_tm,r_tm,n_tm,s_tm,dt\n";
 
 for( auto n0: n0_vec){
@@ -51,6 +51,7 @@ for( auto n0: n0_vec){
     	file <<n0<<","<<m_tm/dt<<","<<r_tm/dt<<","<<n_tm/dt<<","<<s_tm/dt<<","<<dt<<"\n";
     }
 }
+file.close();
 } // for rep
 return 0; 
 } // main


### PR DESCRIPTION
**Modified `plot_figure_2`** to create directories for saving numerical data and figures in the same location.  

**Updated `simulation_figure2`** to close Rep files within the loop, preventing overwriting in each iteration.  

If these changes weren’t intended, feel free to close this PR.  
